### PR TITLE
Add an index on name column of Board

### DIFF
--- a/db/migrate/20140729130650_add_name_index_to_boards.rb
+++ b/db/migrate/20140729130650_add_name_index_to_boards.rb
@@ -1,0 +1,5 @@
+class AddNameIndexToBoards < ActiveRecord::Migration
+  def change
+    add_index :boards, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140729071051) do
+ActiveRecord::Schema.define(version: 20140729130650) do
 
   create_table "boards", force: true do |t|
     t.integer  "owner_id"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 20140729071051) do
 
   add_index "boards", ["alias_board_id"], name: "index_boards_on_alias_board_id"
   add_index "boards", ["linked_board_id"], name: "index_boards_on_linked_board_id"
+  add_index "boards", ["name"], name: "index_boards_on_name"
   add_index "boards", ["owner_id"], name: "index_boards_on_owner_id"
   add_index "boards", ["parent_id"], name: "index_boards_on_parent_id"
 


### PR DESCRIPTION
ea5383016a318092920931c6e3e49964fa36956f actually didn't add an index on name. `index: true` seems to work only with `t.references`.
