### PR TITLE
Show JACKPOT message

### DIFF
--- a/termapp/terminal.rb
+++ b/termapp/terminal.rb
@@ -52,14 +52,17 @@ module TermApp
     # Examples
     #
     #   color_black
+    #   # => :color_black
     #
     #   color_red(reverse: true)
+    #   # => :color_red
     #
     #   color_green do
     #     term.mvaddstr(14, 52, 'Successfully saved!')
     #   end
+    #   # => :color_green
     #
-    # Returns nothing.
+    # Returns the Symbol of used color.
     #
     # Signature
     #
@@ -78,6 +81,7 @@ module TermApp
           @cur_color = color
           @stdscr.attrset(Ncurses.COLOR_PAIR(color))
         end
+        sym
       end
     end
 
@@ -124,7 +128,7 @@ module TermApp
 
     # Public: Set a random color of Terminal. Delegates to color_<color> method.
     #
-    # Returns nothing.
+    # Returns the Symbol of the random color.
     def color_sample(*args, &block)
       send(COLOR_SYMBOLS[0..-2].sample, *args, &block)
     end

--- a/termapp/views/login_menu.rb
+++ b/termapp/views/login_menu.rb
@@ -22,7 +22,8 @@ class LoginMenu < TermApp::View
 
   def draw_login(failed: false)
     term.clrtoeol(0..23)
-    term.color_sample do
+    logo_colors = []
+    logo_colors << term.color_sample do
       term.print_block(2, 2, <<EOF
       =$
  ~OMMMMM8.
@@ -43,7 +44,7 @@ EOF
       )
     end
 
-    term.color_sample do
+    logo_colors << term.color_sample do
       term.print_block(5, 15, <<EOF
            ,=,,
      :OMMMMMMMMM?
@@ -60,7 +61,7 @@ EOF
       )
     end
 
-    term.color_sample do
+    logo_colors << term.color_sample do
       term.print_block(3, 33, <<EOF
        =ZMMMMDI.
    ?MMMD=   =MMMM
@@ -77,7 +78,7 @@ EOF
       )
     end
 
-    term.color_sample do
+    logo_colors << term.color_sample do
       term.print_block(2, 51, <<EOF
      :ZMMMMMMMMM:
    ?MMMMMMMMMMMMM
@@ -96,6 +97,9 @@ EOF
     term.color_white do
       term.mvaddstr(13, 50, 'managed by GoN security')
       term.mvaddstr(14, 52, 'since 1999')
+    end
+    if logo_colors.uniq.size == 1
+      term.color_red { term.mvaddstr(18, 17, 'JACKPOT!!!!') }
     end
     term.mvaddstr(20, 5, 'total hit: 14520652')
     term.mvaddstr(21, 5, 'today hit: 229')


### PR DESCRIPTION
- Exclude `color_white` from `color_sample`
  
  `color_black` and `color_white` are not different. It affects the probability of `color_sample`.
- Make `color_<color>` returns the used color and show the JACKPOT message
