### PR TITLE
Remove `Internal` status keyword for Inch CI

### DIFF
--- a/termapp/application.rb
+++ b/termapp/application.rb
@@ -3,24 +3,24 @@ require_relative 'terminal'
 
 module TermApp
   class Application
-    # Internal: Returns the Terminal instance of the application.
+    # Returns the Terminal instance of the application.
     attr_reader :term
 
-    # Internal: Initialize a Application and run it.
+    # Initialize a Application and run it.
     #
     # Returns nothing.
     def self.run
       new.run
     end
 
-    # Internal: Initialize a Application. Initialize a Terminal.
+    # Initialize a Application. Initialize a Terminal.
     def initialize
       @term = Terminal.new
       @cached_views = {}
     end
 
-    # Internal: Run process of a passed Processors. Get the name of a Processor
-    # and process it with the passed arguments.
+    # Run process of a passed Processors. Get the name of a Processor and
+    # process it with the passed arguments.
     #
     # name - The Symbol of a class inheriting Processor to process.
     # args - Zero or more values to pass to process method of class as
@@ -38,8 +38,8 @@ module TermApp
       view.process(*args)
     end
 
-    # Internal: Main routine of the Application. Process a Processor until it
-    # returns next processor as nil. Terminate the term at the finish.
+    # Main routine of the Application. Process a Processor until it returns next
+    # processor as nil. Terminate the term at the finish.
     #
     # Returns nothing.
     def run
@@ -50,7 +50,7 @@ module TermApp
     end
   end
 
-  # Internal: Main routine of the TermApp. Run the Application.
+  # Main routine of the TermApp. Run the Application.
   #
   # Returns nothing.
   def self.run

--- a/termapp/core_ext/string.rb
+++ b/termapp/core_ext/string.rb
@@ -1,5 +1,5 @@
 class String
-  # Internal: Calculate the size of the String to print on Ncurses screen.
+  # Calculate the size of the String to print on Ncurses screen.
   #
   # Examples
   #

--- a/termapp/processor.rb
+++ b/termapp/processor.rb
@@ -1,16 +1,16 @@
 module TermApp
-  # Internal: Base Processor class. The process method must be implemented. The
-  # process method must return the Symbol of Processor to be processed next with
-  # its arguments or nil for termination.
+  # Base Processor class. The process method must be implemented. The process
+  # method must return the Symbol of Processor to be processed next with its
+  # arguments or nil for termination.
   class Processor
-    # Internal: Initialize a Processor. It holds the Application instance.
+    # Initialize a Processor. It holds the Application instance.
     #
     # app - The Application instance which is now running.
     def initialize(app)
       @app = app
     end
 
-    # Internal: Delegates all missing methods to the application.
+    # Delegates all missing methods to the application.
     #
     # meth - The Symbol of a missing method.
     # args - Zero or more values to pass to method as parameters.

--- a/termapp/processors/loco_menu.rb
+++ b/termapp/processors/loco_menu.rb
@@ -1,17 +1,17 @@
 class LocoMenu < TermApp::Processor
-  # Internal: Item of LocoMenu. Contains a regex for shortcut, title and a menu
-  # symbol of the class inheriting Processor.
+  # Item of LocoMenu. Contains a regex for shortcut, title and a menu symbol of
+  # the class inheriting Processor.
   class Item
-    # Internal: Returns the Regexp shortcut for the menu.
+    # Returns the Regexp shortcut for the menu.
     attr_reader :shortcut_regex
 
-    # Internal: Returns the String title of the menu.
+    # Returns the String title of the menu.
     attr_reader :title
 
-    # Internal: Returns the Symbol of the class inheriting Processor.
+    # Returns the Symbol of the class inheriting Processor.
     attr_reader :menu
 
-    # Internal: Initialize a Item of LocoMenu.
+    # Initialize a Item of LocoMenu.
     #
     # name      - A String indicates which menu it is.
     # bind_menu - The Symbol of the class inheriting Processor of which the
@@ -36,8 +36,8 @@ class LocoMenu < TermApp::Processor
     super
   end
 
-  # Internal: Main routine of LocoMenu. Show menus. User can navigate menus and
-  # select a menu.
+  # Main routine of LocoMenu. Show menus. User can navigate menus and select a
+  # menu.
   #
   # Returns a Symbol of Processor with its process arguments or nil.
   def process
@@ -61,7 +61,7 @@ class LocoMenu < TermApp::Processor
     menu_helper(items.freeze)
   end
 
-  # Internal: Helper for main of LocoMenu.
+  # Helper for main of LocoMenu.
   #
   # items    - The Array of Item instances of menu to show.
   #

--- a/termapp/terminal.rb
+++ b/termapp/terminal.rb
@@ -1,8 +1,8 @@
 require_relative 'core_ext/string'
 
 module TermApp
-  # Internal: Wrapper for Ncurses to do terminal operations. Make sure to call
-  # terminate before termination of the program.
+  # Wrapper for Ncurses to do terminal operations. Make sure to call terminate
+  # before termination of the program.
   #
   # Examples
   #
@@ -14,16 +14,16 @@ module TermApp
   class Terminal
     extend Forwardable
 
-    # Internal: Delegates erase, noecho, echo, beep to each method of Ncurses.
+    # Delegates erase, noecho, echo, beep to each method of Ncurses.
     def_delegators :Ncurses, :erase, :noecho, :echo, :beep
 
-    # Internal: Delegates terminate to Ncurses.endwin.
+    # Delegates terminate to Ncurses.endwin.
     def_delegator :Ncurses, :endwin, :terminate
 
-    # Internal: Delegates refresh, move, getch to each method of @stdscr.
+    # Delegates refresh, move, getch to each method of @stdscr.
     def_delegators :@stdscr, :refresh, :move, :getch
 
-    # Internal: The constants for color of Ncurses.
+    # The constants for color of Ncurses.
     COLOR_BLACK = 0
     COLOR_RED = 1
     COLOR_GREEN = 2
@@ -38,8 +38,8 @@ module TermApp
                        color_blue color_magenta color_cyan color_white).freeze
     private_constant :COLORS, :COLOR_SYMBOLS
 
-    # Internal: Set a color of Terminal. This method will be available for each
-    # color initialized on Ncurses.
+    # Set a color of Terminal. This method will be available for each color
+    # initialized on Ncurses.
     #
     # options - The Hash options used to refine the color
     #           (default: { reverse: false }):
@@ -88,8 +88,8 @@ module TermApp
     attr_accessor :current_user
     attr_accessor :current_board
 
-    # Internal: Initialize a Terminal. Set initial Ncurses configurations and
-    # start Ncurses screen.
+    # Initialize a Terminal. Set initial Ncurses configurations and start
+    # Ncurses screen.
     #
     # encoding - The Encoding of Terminal.
     #
@@ -127,8 +127,7 @@ module TermApp
       Ncurses.raw
     end
 
-    # Internal: Set a random color of Terminal. Delegates to color_<color>
-    # method.
+    # Set a random color of Terminal. Delegates to color_<color> method.
     #
     #
     # Examples


### PR DESCRIPTION
Inci CI doesn't show `Internal` documents. See [current status](http://inch-ci.org/github/khwon/loco).
