### PR TITLE
Change values of .rubocop.yml to default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,8 +30,5 @@ Style/Documentation:
     - 'app/helpers/application_helper.rb'
     - 'test/test_helper.rb'
 
-Style/Encoding:
-  Enabled: true
-
 Style/MethodLength:
   Enabled: false


### PR DESCRIPTION
- Use default `Style/IndentHash`: `special_inside_parentheses`
  
  This is `consistent` style:
  
  ``` ruby
  some_method(value, {
    one: 1,
    two: 2
  },
              another_value)
  ```
  
  This is `special_inside_parentheses` style:
  
  ``` ruby
  some_method(value, {
                one: 1,
                two: 2,
              },
              another_value)
  ```
  
  Both style passes this:
  
  ``` ruby
  some_method(value,
              {
                one: 1,
                two: 2
              },
              another_value)
  ```
- Disable `Style/MethodCalledOnDoEndBlock`
  
  Because this blocks every method call on do ... end block, even if it is just simple `join` or `flatten`:
  
  ``` ruby
  [1, 2, 3].map do |v|
    (v + 1).to_s
  end.join
  ```
  
  But we should still avoid chaining multi-line blocks: https://github.com/bbatsov/ruby-style-guide#single-line-blocks
