### PR TITLE
Fix bug `id` and `pw` are not cleared on login fail

### DIFF
--- a/termapp/processors/login_menu.rb
+++ b/termapp/processors/login_menu.rb
@@ -2,9 +2,9 @@ class LoginMenu < TermApp::Processor
   def process
     user = nil
     tried = false
-    id = ''
-    pw = ''
     until user
+      id = ''
+      pw = ''
       draw_login(failed: tried)
       tried = true
       term.mvgetnstr(20, 40, id, 20)


### PR DESCRIPTION
If user failed to login once, user can't login even if the inputs are correct. Passing 'off' as id won't work, too.
