### PR TITLE
Fix bug that calls clrtoeol on wrong line

### DIFF
--- a/termapp/processors/select_board_menu.rb
+++ b/termapp/processors/select_board_menu.rb
@@ -27,7 +27,7 @@ class SelectBoardMenu < TermApp::Processor
       term.mvaddstr(3, 1, "select board : #{str}")
       term.refresh
       c = term.getch
-      term.clrtoeol(2)
+      term.clrtoeol(3)
       case c
       when 9, 32 # tab, space
         if cur_boards.size == 1 && str != cur_boards.first.path_name


### PR DESCRIPTION
Currently it is hidden by `erase_body`.
