### PR TITLE
Fix RuboCop offenses

### DIFF
--- a/termapp/core_ext/string.rb
+++ b/termapp/core_ext/string.rb
@@ -16,20 +16,18 @@ class String
   end
 
   def unicode_slice(length)
-    if self.size_for_print <= length
+    if size_for_print <= length
       self
     else
       if self.ascii_only?
-        self[0..(size-2)] + ".."
+        self[0..(size - 2)] + '..'
       else
-        result = ""
+        result = ''
         # TODO : need optimize
-        self.each_char do |x|
-          if result.size_for_print < length - 2
-            result << x
-          end
+        each_char do |x|
+          result << x if result.size_for_print < length - 2
         end
-        result + ".."
+        result + '..'
       end
     end
   end

--- a/termapp/processors/read_board_menu.rb
+++ b/termapp/processors/read_board_menu.rb
@@ -5,12 +5,12 @@ class ReadBoardMenu < TermApp::Processor
     term.erase_body
     cur_board = term.current_board
     if cur_board
-      posts = cur_board.post.order("num desc").limit(term.lines - 5)
+      posts = cur_board.post.order('num desc').limit(term.lines - 5)
       posts.reverse.each_with_index do |x, i|
         str = format('%8d', x.num)
-        str += format(' %13s',x.writer.nickname)
-        str += '??' # 날짜
-        str += '??' # 조회수
+        str += format(' %13s', x.writer.nickname)
+        str += '??' # Date
+        str += '??' # View count
         str += x.title
         term.mvaddstr(i + 4, 1, str)
       end


### PR DESCRIPTION
- Remove redundant `self`
- Use single-quote strings
- Add space for operator and comma
- Prefer one line `if` statement
- Use ascii comments
