### PR TITLE
Move all Processors into TermApp module

### DIFF
--- a/spec/support/termapp_helper.rb
+++ b/spec/support/termapp_helper.rb
@@ -10,7 +10,9 @@ module TermAppHelpers
     end
 
     def contain_all?(expected, actual)
-      expected.all? { |e| actual[e].is_a? e.to_s.classify.constantize }
+      expected.all? do |e|
+        actual[e].is_a? "TermApp::#{e.to_s.classify}".constantize
+      end
     end
   end
 

--- a/termapp/application.rb
+++ b/termapp/application.rb
@@ -36,7 +36,7 @@ module TermApp
     def process(name, *args)
       processor = @cached_processors[name] ||=
         begin
-          klass = name.to_s.classify.constantize
+          klass = "TermApp::#{name.to_s.classify}".constantize
           klass.new(self)
         rescue NameError
           NotImplementedMenu.new(name, self)

--- a/termapp/processors/goodbye_menu.rb
+++ b/termapp/processors/goodbye_menu.rb
@@ -1,11 +1,13 @@
-# Corresponding Processor of LocoMenu::Item.new('Goodbye'). Terminate the
-# Application after processing.
-class GoodbyeMenu < TermApp::Processor
-  def process
-    term.erase
-    term.mvaddstr(5, 5, 'goodbye!')
-    term.refresh
-    term.getch
-    nil
+module TermApp
+  # Corresponding Processor of LocoMenu::Item.new('Goodbye'). Terminate the
+  # Application after processing.
+  class GoodbyeMenu < Processor
+    def process
+      term.erase
+      term.mvaddstr(5, 5, 'goodbye!')
+      term.refresh
+      term.getch
+      nil
+    end
   end
 end

--- a/termapp/processors/loco_menu.rb
+++ b/termapp/processors/loco_menu.rb
@@ -1,133 +1,135 @@
-# Main processor of the Application. User can navigate menus and select a menu.
-# Processed after WelcomeMenu.
-class LocoMenu < TermApp::Processor
-  # Item of LocoMenu. Contains a regex for shortcut, title and a menu symbol of
-  # the class inheriting Processor.
-  class Item
-    # Returns the Regexp shortcut for the menu.
-    attr_reader :shortcut_regex
+module TermApp
+  # Main processor of the Application. User can navigate menus and select a
+  # menu. Processed after WelcomeMenu.
+  class LocoMenu < Processor
+    # Item of LocoMenu. Contains a regex for shortcut, title and a menu symbol
+    # of the class inheriting Processor.
+    class Item
+      # Returns the Regexp shortcut for the menu.
+      attr_reader :shortcut_regex
 
-    # Returns the String title of the menu.
-    attr_reader :title
+      # Returns the String title of the menu.
+      attr_reader :title
 
-    # Returns the Symbol of the class inheriting Processor.
-    attr_reader :menu
+      # Returns the Symbol of the class inheriting Processor.
+      attr_reader :menu
 
-    # Initialize a Item of LocoMenu.
+      # Initialize a Item of LocoMenu.
+      #
+      # name      - A String indicates which menu it is.
+      # bind_menu - The Symbol of the class inheriting Processor of which the
+      #             process method to be called when selected
+      #             (default: "#{name}Menu".camelize.underscore.to_sym).
+      #
+      # Examples
+      #
+      #   Item.new('Post')
+      #
+      #   Item.new('New', :read_new_menu)
+      def initialize(name, bind_menu = "#{name}Menu".camelize.underscore.to_sym)
+        @shortcut_regex = Regexp.new("[#{name[0].upcase}#{name[0].downcase}]")
+        @title = name.camelize.sub(/^(.)/, '(\\1)')
+        @menu = bind_menu
+      end
+    end
+
+    # Initialize a LocoMenu. Initialize cur_menu and past_menu.
     #
-    # name      - A String indicates which menu it is.
-    # bind_menu - The Symbol of the class inheriting Processor of which the
-    #             process method to be called when selected
-    #             (default: "#{name}Menu".camelize.underscore.to_sym).
+    # args - Zero or more values to pass to initialize of super class as
+    #        parameters.
     #
     # Examples
     #
-    #   Item.new('Post')
-    #
-    #   Item.new('New', :read_new_menu)
-    def initialize(name, bind_menu = "#{name}Menu".camelize.underscore.to_sym)
-      @shortcut_regex = Regexp.new("[#{name[0].upcase}#{name[0].downcase}]")
-      @title = name.camelize.sub(/^(.)/, '(\\1)')
-      @menu = bind_menu
-    end
-  end
-
-  # Initialize a LocoMenu. Initialize cur_menu and past_menu.
-  #
-  # args - Zero or more values to pass to initialize of super class as
-  #        parameters.
-  #
-  # Examples
-  #
-  #   LocoMenu.new(app)
-  def initialize(*args)
-    super
-    @cur_menu = 0
-    @past_menu = nil
-    @items = [Item.new('New', :read_new_menu),
-              Item.new('Boards', :print_board_menu),
-              Item.new('Select', :select_board_menu),
-              Item.new('Read', :read_board_menu)]
-    @items.concat(
-      %w(Post Talk Mail Diary Welcome Xyz Goodbye Help)
-        .map { |name| Item.new(name) })
-    # @items.concat(%w(Extra Visit InfoBBS).map { |name| Item.new(name) }))
-    @items << Item.new('Admin') if term.current_user.admin?
-    @items.freeze
-  end
-
-  # Main routine of LocoMenu. Show menus. User can navigate menus and select a
-  # menu.
-  #
-  # Returns a Symbol of Processor with its process arguments or nil.
-  def process
-    loop do
-      term.noecho
-      print_items
-      term.move(@cur_menu + 4, 3)
-      term.refresh
-      control, *args = process_key(term.getch)
-      case control
-      when :break
-        break args
-      end
-    end
-  end
-
-  # Process key input for LocoMenu.
-  #
-  # key - A Integer key input which is returned from term.getch.
-  #
-  # Examples
-  #
-  #   process_key(term.getch)
-  #
-  #   process_key(10)
-  #   # => [:break, :welcome_menu]
-  #
-  # Returns nil or a Symbol :break with additional arguments.
-  def process_key(key)
-    case key
-    when Ncurses::KEY_UP
-      @past_menu = @cur_menu
-      @cur_menu = (@cur_menu - 1) % @items.size
-    when Ncurses::KEY_DOWN
-      @past_menu = @cur_menu
-      @cur_menu = (@cur_menu + 1) % @items.size
-    when Ncurses::KEY_ENTER, 10 # Enter
-      # Erase body after call
+    #   LocoMenu.new(app)
+    def initialize(*args)
+      super
+      @cur_menu = 0
       @past_menu = nil
-      term.echo
-      return :break, @items[@cur_menu].menu
-    else
-      return unless key < 127
-      @items.each_with_index do |item, i|
-        next unless key.chr =~ item.shortcut_regex
-        @past_menu = @cur_menu
-        @cur_menu = i
-      end
+      @items = [Item.new('New', :read_new_menu),
+                Item.new('Boards', :print_board_menu),
+                Item.new('Select', :select_board_menu),
+                Item.new('Read', :read_board_menu)]
+      @items.concat(
+        %w(Post Talk Mail Diary Welcome Xyz Goodbye Help)
+          .map { |name| Item.new(name) })
+      # @items.concat(%w(Extra Visit InfoBBS).map { |name| Item.new(name) }))
+      @items << Item.new('Admin') if term.current_user.admin?
+      @items.freeze
     end
-  end
 
-  # Print Items of menu. Refresh only changed lines if past_menu exists.
-  #
-  # Returns nothing.
-  def print_items
-    if @past_menu.nil?
-      term.erase_body
-      @items.each_with_index do |item, i|
-        if i == @cur_menu
-          term.color_black(reverse: true) do
-            term.mvaddstr(i + 4, 3, item.title)
-          end
-        else
-          term.mvaddstr(i + 4, 3, item.title)
+    # Main routine of LocoMenu. Show menus. User can navigate menus and select a
+    # menu.
+    #
+    # Returns a Symbol of Processor with its process arguments or nil.
+    def process
+      loop do
+        term.noecho
+        print_items
+        term.move(@cur_menu + 4, 3)
+        term.refresh
+        control, *args = process_key(term.getch)
+        case control
+        when :break
+          break args
         end
       end
-    else
-      term.mvaddstr(@past_menu + 4, 3, @items[@past_menu].title)
-      term.color_black(reverse: true) do
-        term.mvaddstr(@cur_menu + 4, 3, @items[@cur_menu].title)
+    end
+
+    # Process key input for LocoMenu.
+    #
+    # key - A Integer key input which is returned from term.getch.
+    #
+    # Examples
+    #
+    #   process_key(term.getch)
+    #
+    #   process_key(10)
+    #   # => [:break, :welcome_menu]
+    #
+    # Returns nil or a Symbol :break with additional arguments.
+    def process_key(key)
+      case key
+      when Ncurses::KEY_UP
+        @past_menu = @cur_menu
+        @cur_menu = (@cur_menu - 1) % @items.size
+      when Ncurses::KEY_DOWN
+        @past_menu = @cur_menu
+        @cur_menu = (@cur_menu + 1) % @items.size
+      when Ncurses::KEY_ENTER, 10 # Enter
+        # Erase body after call
+        @past_menu = nil
+        term.echo
+        return :break, @items[@cur_menu].menu
+      else
+        return unless key < 127
+        @items.each_with_index do |item, i|
+          next unless key.chr =~ item.shortcut_regex
+          @past_menu = @cur_menu
+          @cur_menu = i
+        end
+      end
+    end
+
+    # Print Items of menu. Refresh only changed lines if past_menu exists.
+    #
+    # Returns nothing.
+    def print_items
+      if @past_menu.nil?
+        term.erase_body
+        @items.each_with_index do |item, i|
+          if i == @cur_menu
+            term.color_black(reverse: true) do
+              term.mvaddstr(i + 4, 3, item.title)
+            end
+          else
+            term.mvaddstr(i + 4, 3, item.title)
+          end
+        end
+      else
+        term.mvaddstr(@past_menu + 4, 3, @items[@past_menu].title)
+        term.color_black(reverse: true) do
+          term.mvaddstr(@cur_menu + 4, 3, @items[@cur_menu].title)
+        end
       end
     end
   end

--- a/termapp/processors/login_menu.rb
+++ b/termapp/processors/login_menu.rb
@@ -1,47 +1,48 @@
-# Process login screen. Processed at first. Terminate the Application when user
-# input 'off' on id field.
-class LoginMenu < TermApp::Processor
-  def process
-    user = nil
-    tried = false
-    until user
-      id = ''
-      pw = ''
-      draw_login(failed: tried)
-      tried = true
-      term.mvgetnstr(20, 40, id, 20)
-      return :goodbye_menu if id == 'off'
-      term.mvgetnstr(21, 40, pw, 20, echo: false)
-      if id != 'new'
-        user = User.find_by(username: id).try(:authenticate, pw)
+module TermApp
+  # Process login screen. Processed at first. Terminate the Application when
+  # user input 'off' on id field.
+  class LoginMenu < Processor
+    def process
+      user = nil
+      tried = false
+      until user
+        id = ''
+        pw = ''
+        draw_login(failed: tried)
+        tried = true
+        term.mvgetnstr(20, 40, id, 20)
+        return :goodbye_menu if id == 'off'
+        term.mvgetnstr(21, 40, pw, 20, echo: false)
+        if id != 'new'
+          user = User.find_by(username: id).try(:authenticate, pw)
+        end
       end
+      term.current_user = user
+      :welcome_menu
     end
-    term.current_user = user
-    :welcome_menu
-  end
 
-  private
+    private
 
-  # Draw login page with the logo of Loco. Each character of logo is colored
-  # randomly. If every letter has same color, print 'JACKPOT!!!!' on screen.
-  #
-  # options - The Hash options used to print login failed message
-  #           (default: { failed: false }):
-  #           :failed - The Boolean indicates whether user has failed to login
-  #                     or not (optional).
-  #
-  # Examples
-  #
-  #   draw_login
-  #
-  #   draw_login(failed: true)
-  #
-  # Returns nothing.
-  def draw_login(failed: false)
-    term.clrtoeol(0..23)
-    logo_colors = []
-    logo_colors << term.color_sample do
-      term.print_block(2, 2, <<END
+    # Draw login page with the logo of Loco. Each character of logo is colored
+    # randomly. If every letter has same color, print 'JACKPOT!!!!' on screen.
+    #
+    # options - The Hash options used to print login failed message
+    #           (default: { failed: false }):
+    #           :failed - The Boolean indicates whether user has failed to login
+    #                     or not (optional).
+    #
+    # Examples
+    #
+    #   draw_login
+    #
+    #   draw_login(failed: true)
+    #
+    # Returns nothing.
+    def draw_login(failed: false)
+      term.clrtoeol(0..23)
+      logo_colors = []
+      logo_colors << term.color_sample do
+        term.print_block(2, 2, <<END
       =$
  ~OMMMMM8.
 MMMMMMMMM+
@@ -58,11 +59,11 @@ MMMMMMMMM+
      .MMMMZI$.
      =+.
 END
-      )
-    end
+        )
+      end
 
-    logo_colors << term.color_sample do
-      term.print_block(5, 15, <<END
+      logo_colors << term.color_sample do
+        term.print_block(5, 15, <<END
            ,=,,
      :OMMMMMMMMM?
    ?MMMMMMMMMMMMM
@@ -75,11 +76,11 @@ END
     +MMMMMMMMI.
        .  .
 END
-      )
-    end
+        )
+      end
 
-    logo_colors << term.color_sample do
-      term.print_block(3, 33, <<END
+      logo_colors << term.color_sample do
+        term.print_block(3, 33, <<END
        =ZMMMMDI.
    ?MMMD=   =MMMM
  IMMMM8  $MMMMMMMO
@@ -92,11 +93,11 @@ OMMMMMM    .
    MMMMMMMMMM+.
      ,.~ ..
 END
-      )
-    end
+        )
+      end
 
-    logo_colors << term.color_sample do
-      term.print_block(2, 51, <<END
+      logo_colors << term.color_sample do
+        term.print_block(2, 51, <<END
      :ZMMMMMMMMM:
    ?MMMMMMMMMMMMM
  .DMMMMMMMMMMMMMM
@@ -108,19 +109,19 @@ END
    .$MMMMMMMM7
           .
 END
-      )
-    end
+        )
+      end
 
-    term.color_white do
-      term.mvaddstr(13, 50, 'managed by GoN security')
-      term.mvaddstr(14, 52, 'since 1999')
-    end
-    if logo_colors.uniq.size == 1
-      term.color_red { term.mvaddstr(18, 17, 'JACKPOT!!!!') }
-    end
-    term.mvaddstr(20, 5, 'total hit: 14520652')
-    term.mvaddstr(21, 5, 'today hit: 229')
-    term.print_block(17, 32, <<END
+      term.color_white do
+        term.mvaddstr(13, 50, 'managed by GoN security')
+        term.mvaddstr(14, 52, 'since 1999')
+      end
+      if logo_colors.uniq.size == 1
+        term.color_red { term.mvaddstr(18, 17, 'JACKPOT!!!!') }
+      end
+      term.mvaddstr(20, 5, 'total hit: 14520652')
+      term.mvaddstr(21, 5, 'today hit: 229')
+      term.print_block(17, 32, <<END
    type 'new' to join
    there is no guest ID
 ┌──────────────────────────────┐
@@ -129,8 +130,9 @@ END
 │                              │
 └──────────────────────────────┘
 END
-    )
-    term.mvaddstr(22, 35, 'Login failed!') if failed
-    term.refresh
+      )
+      term.mvaddstr(22, 35, 'Login failed!') if failed
+      term.refresh
+    end
   end
 end

--- a/termapp/processors/not_implemented_menu.rb
+++ b/termapp/processors/not_implemented_menu.rb
@@ -1,25 +1,27 @@
-# Print the message saying this menu is not implemented yet.
-class NotImplementedMenu < TermApp::Processor
-  # Initialize a NotImplementedMenu. It holds the Symbol of the menu which is
-  # not implemented yet.
-  #
-  # name - The Symbol of the menu which is not implemented yet.
-  # args - Zero or more values to pass to initialize of super class as
-  #        parameters.
-  #
-  # Examples
-  #
-  #   NotImplementedMenu.new(:future_menu, app)
-  def initialize(name, *args)
-    @name = name
-    super(*args)
-  end
+module TermApp
+  # Print the message saying this menu is not implemented yet.
+  class NotImplementedMenu < Processor
+    # Initialize a NotImplementedMenu. It holds the Symbol of the menu which is
+    # not implemented yet.
+    #
+    # name - The Symbol of the menu which is not implemented yet.
+    # args - Zero or more values to pass to initialize of super class as
+    #        parameters.
+    #
+    # Examples
+    #
+    #   NotImplementedMenu.new(:future_menu, app)
+    def initialize(name, *args)
+      @name = name
+      super(*args)
+    end
 
-  def process
-    term.erase_body
-    term.mvaddstr(5, 5, "#{@name}: Not supported yet")
-    term.refresh
-    term.getch
-    :loco_menu
+    def process
+      term.erase_body
+      term.mvaddstr(5, 5, "#{@name}: Not supported yet")
+      term.refresh
+      term.getch
+      :loco_menu
+    end
   end
 end

--- a/termapp/processors/print_board_menu.rb
+++ b/termapp/processors/print_board_menu.rb
@@ -1,14 +1,16 @@
-# Corresponding Processor of LocoMenu::Item.new('Boards', :print_board_menu).
-# Print the child Board list of current Board.
-class PrintBoardMenu < TermApp::Processor
-  def process
-    term.erase_body
-    Board.get_list(parent_board: term.current_board).each_with_index do |x, i|
-      term.mvaddstr(i + 4, 3, x.path_name)
+module TermApp
+  # Corresponding Processor of LocoMenu::Item.new('Boards', :print_board_menu).
+  # Print the child Board list of current Board.
+  class PrintBoardMenu < Processor
+    def process
+      term.erase_body
+      Board.get_list(parent_board: term.current_board).each_with_index do |x, i|
+        term.mvaddstr(i + 4, 3, x.path_name)
+      end
+      term.mvaddstr(3, 20, 'Press any key..')
+      term.refresh
+      term.getch
+      :loco_menu
     end
-    term.mvaddstr(3, 20, 'Press any key..')
-    term.refresh
-    term.getch
-    :loco_menu
   end
 end

--- a/termapp/processors/read_board_menu.rb
+++ b/termapp/processors/read_board_menu.rb
@@ -1,25 +1,27 @@
-# Corresponding Processor of LocoMenu::Item.new('Read', :read_board_menu). Print
-# the Post list of current Board.
-class ReadBoardMenu < TermApp::Processor
-  def process
-    term.erase_body
-    cur_board = term.current_board
-    if cur_board
-      posts = cur_board.post.order('num desc').limit(term.lines - 5)
-      posts.reverse.each_with_index do |x, i|
-        strs = []
-        strs << format('%6d', x.num)
-        strs << format('%-12s', x.writer.nickname)
-        strs << x.created_at.strftime('%m/%d') # Date
-        strs << '????' # View count
-        strs << x.title.unicode_slice(term.columns - 32)
-        term.mvaddstr(i + 4, 1, strs.join(' '))
+module TermApp
+  # Corresponding Processor of LocoMenu::Item.new('Read', :read_board_menu).
+  # Print the Post list of current Board.
+  class ReadBoardMenu < Processor
+    def process
+      term.erase_body
+      cur_board = term.current_board
+      if cur_board
+        posts = cur_board.post.order('num desc').limit(term.lines - 5)
+        posts.reverse.each_with_index do |x, i|
+          strs = []
+          strs << format('%6d', x.num)
+          strs << format('%-12s', x.writer.nickname)
+          strs << x.created_at.strftime('%m/%d') # Date
+          strs << '????' # View count
+          strs << x.title.unicode_slice(term.columns - 32)
+          term.mvaddstr(i + 4, 1, strs.join(' '))
+        end
+      else
+        term.mvaddstr(8, 8, '보드를 먼저 선택해 주세요')
       end
-    else
-      term.mvaddstr(8, 8, '보드를 먼저 선택해 주세요')
+      term.refresh
+      term.getch
+      :loco_menu
     end
-    term.refresh
-    term.getch
-    :loco_menu
   end
 end

--- a/termapp/processors/select_board_menu.rb
+++ b/termapp/processors/select_board_menu.rb
@@ -1,116 +1,119 @@
-# Corresponding Processor of LocoMenu::Item.new('Select', :select_board_menu).
-# User can navigate Boards and select a Board.
-class SelectBoardMenu < TermApp::Processor
-  def process
-    @str = ''
-    @cur_boards = []
-    @past_boards = nil
-    @list = nil
-    @selected = []
-    loop do
-      # TODO : consider setting start point as locoterm.current_board
-      if @str == ''
-        @past_boards = @cur_boards
-        @cur_boards = []
-      end
-      list = if @selected.last.nil? || @selected.last.is_dir
-               Board.get_list(parent_board: @selected.last)
-             else
-               Board.get_list(parent_board: @selected[-2])
-             end
-      print_boards(list)
-      term.mvaddstr(3, 1, "select board : #{@str}")
-      term.refresh
-      key = term.getch
-      term.clrtoeol(3)
-      control, *args = process_key(key)
-      case control
-      when :break
-        break args
-      when :beep
-        term.beep
-      end
-    end
-  end
-
-  # Process key input for SelectBoardMenu.
-  #
-  # key - A Integer key input which is returned from term.getch.
-  #
-  # Examples
-  #
-  #   process_key(term.getch)
-  #
-  #   process_key(10)
-  #   # => :beep
-  #
-  #   process_key(27)
-  #   # => [:break, :loco_menu]
-  #
-  # Returns nil or a Symbol which is one of :break or :beep with additional
-  #   arguments.
-  def process_key(key)
-    case key
-    when 9, 32 # Tab, Space
-      unless @cur_boards.size == 1 && @str != @cur_boards.first.path_name
-        return :beep
-      end
-      @selected << @cur_boards.first
-      @str = @selected.last.path_name
-    when 27 # ESC
-      return :break, :loco_menu
-    when Ncurses::KEY_ENTER, 10 # Enter
-      return :beep unless @cur_boards.size == 1 && !@cur_boards.first.is_dir
-      # TODO : for now, only allow selecting non-dir boards
-      term.current_board = @cur_boards.first
-      # TODO : for now, return to loco menu
-      return :break, :loco_menu
-    when 127, Ncurses::KEY_BACKSPACE
-      if @selected.size > 0 && @str == @selected.last.path_name
-        @past_boards = @cur_boards
-        @cur_boards = [@selected.pop]
-      end
-      @str = @str[0..-2]
-    else
-      return unless key < 127
-      matched = @list.select { |x| x.path_name.starts_with? @str + key.chr }
-      return :beep unless matched.size > 0
-      @past_boards = @cur_boards
-      @cur_boards = matched
-      @str += key.chr
-    end
-  end
-
-  # Print given Board list. Current Board is printed in reversed color. Refresh
-  # only changed lines if previous list exists and is same with passed list.
-  #
-  # list - The Array of Board to print.
-  #
-  # Returns nothing.
-  def print_boards(list)
-    if @list && @list == list
-      past_board = @list.index(@past_boards.first)
-      cur_board = @list.index(@cur_boards.first)
-      if past_board
-        term.mvaddstr(past_board + 4, 3, @past_boards.first.path_name)
-      end
-      if cur_board
-        term.color_black(reverse: true) do
-          term.mvaddstr(cur_board + 4, 3, @cur_boards.first.path_name)
+module TermApp
+  # Corresponding Processor of LocoMenu::Item.new('Select', :select_board_menu).
+  # User can navigate Boards and select a Board.
+  class SelectBoardMenu < Processor
+    def process
+      @str = ''
+      @cur_boards = []
+      @past_boards = nil
+      @list = nil
+      @selected = []
+      loop do
+        # TODO : consider setting start point as locoterm.current_board
+        if @str == ''
+          @past_boards = @cur_boards
+          @cur_boards = []
+        end
+        list = if @selected.last.nil? || @selected.last.is_dir
+                 Board.get_list(parent_board: @selected.last)
+               else
+                 Board.get_list(parent_board: @selected[-2])
+               end
+        print_boards(list)
+        term.mvaddstr(3, 1, "select board : #{@str}")
+        term.refresh
+        key = term.getch
+        term.clrtoeol(3)
+        control, *args = process_key(key)
+        case control
+        when :break
+          break args
+        when :beep
+          term.beep
         end
       end
-    else
-      term.erase_body
-      list.each_with_index do |x, i|
-        if x == @cur_boards.first
+    end
+
+    # Process key input for SelectBoardMenu.
+    #
+    # key - A Integer key input which is returned from term.getch.
+    #
+    # Examples
+    #
+    #   process_key(term.getch)
+    #
+    #   process_key(10)
+    #   # => :beep
+    #
+    #   process_key(27)
+    #   # => [:break, :loco_menu]
+    #
+    # Returns nil or a Symbol which is one of :break or :beep with additional
+    #   arguments.
+    def process_key(key)
+      case key
+      when 9, 32 # Tab, Space
+        unless @cur_boards.size == 1 && @str != @cur_boards.first.path_name
+          return :beep
+        end
+        @selected << @cur_boards.first
+        @str = @selected.last.path_name
+      when 27 # ESC
+        return :break, :loco_menu
+      when Ncurses::KEY_ENTER, 10 # Enter
+        return :beep unless @cur_boards.size == 1 && !@cur_boards.first.is_dir
+        # TODO : for now, only allow selecting non-dir boards
+        term.current_board = @cur_boards.first
+        # TODO : for now, return to loco menu
+        return :break, :loco_menu
+      when 127, Ncurses::KEY_BACKSPACE
+        if @selected.size > 0 && @str == @selected.last.path_name
+          @past_boards = @cur_boards
+          @cur_boards = [@selected.pop]
+        end
+        @str = @str[0..-2]
+      else
+        return unless key < 127
+        matched = @list.select { |x| x.path_name.starts_with? @str + key.chr }
+        return :beep unless matched.size > 0
+        @past_boards = @cur_boards
+        @cur_boards = matched
+        @str += key.chr
+      end
+    end
+
+    # Print given Board list. Current Board is printed in reversed color.
+    # Refresh only changed lines if previous list exists and is same with passed
+    # list.
+    #
+    # list - The Array of Board to print.
+    #
+    # Returns nothing.
+    def print_boards(list)
+      if @list && @list == list
+        past_board = @list.index(@past_boards.first)
+        cur_board = @list.index(@cur_boards.first)
+        if past_board
+          term.mvaddstr(past_board + 4, 3, @past_boards.first.path_name)
+        end
+        if cur_board
           term.color_black(reverse: true) do
+            term.mvaddstr(cur_board + 4, 3, @cur_boards.first.path_name)
+          end
+        end
+      else
+        term.erase_body
+        list.each_with_index do |x, i|
+          if x == @cur_boards.first
+            term.color_black(reverse: true) do
+              term.mvaddstr(i + 4, 3, x.path_name)
+            end
+          else
             term.mvaddstr(i + 4, 3, x.path_name)
           end
-        else
-          term.mvaddstr(i + 4, 3, x.path_name)
         end
+        @list = list
       end
-      @list = list
     end
   end
 end

--- a/termapp/processors/welcome_menu.rb
+++ b/termapp/processors/welcome_menu.rb
@@ -1,11 +1,13 @@
-# Corresponding Processor of LocoMenu::Item.new('Welcome'). Processed when user
-# logged in. Print welcome message to screen.
-class WelcomeMenu < TermApp::Processor
-  def process
-    term.erase
-    term.mvaddstr(15, 30, 'welcome to new loco!')
-    term.refresh
-    term.getch
-    :loco_menu
+module TermApp
+  # Corresponding Processor of LocoMenu::Item.new('Welcome'). Processed when
+  # user logged in. Print welcome message to screen.
+  class WelcomeMenu < Processor
+    def process
+      term.erase
+      term.mvaddstr(15, 30, 'welcome to new loco!')
+      term.refresh
+      term.getch
+      :loco_menu
+    end
   end
 end


### PR DESCRIPTION
You can see actual diff with `git diff -b`. Also, if there is another good way to represent:

``` ruby
"TermApp::#{name.to_s.classify}".constantize
```

then please let me know. I found

``` irb
>> TermApp::Processor.name.deconstantize
=> "TermApp"
```

but it's hard to use in `spec/support/termapp_helper.rb`.
