### PR TITLE
Move `Exclude` from `.rubocop.yml` to each file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,8 +11,3 @@ AllCops:
     - 'bin/**/*'
     - 'config/**/*'
     - 'db/**/*'
-
-Style/AsciiComments:
-  Exclude:
-    - 'termapp/core_ext/string.rb'
-    - 'spec/termapp/core_ext/string_spec.rb'

--- a/spec/termapp/core_ext/string_spec.rb
+++ b/spec/termapp/core_ext/string_spec.rb
@@ -1,3 +1,5 @@
+# rubocop:disable Style/AsciiComments
+
 require 'rails_helper'
 require 'core_ext/string'
 require 'terminal'

--- a/termapp/core_ext/string.rb
+++ b/termapp/core_ext/string.rb
@@ -1,3 +1,5 @@
+# rubocop:disable Style/AsciiComments
+
 # Extend String class of Ruby core.
 class String
   # Calculate the size of the String to print on Ncurses screen.


### PR DESCRIPTION
I think it'll be more self-descriptive. We can lock `.rubocop.yml` from now.
