### PR TITLE
Rename helper modules and move to separate files

### DIFF
--- a/spec/support/login_helper.rb
+++ b/spec/support/login_helper.rb
@@ -1,5 +1,5 @@
 # Helper methods for login process test of TermApp::Application.
-module LoginHelpers
+module LoginHelper
   def mock_id_input(term, dummy_id)
     mocking = true
     allow(term).to receive(:mvgetnstr).with(

--- a/spec/support/termapp_helper.rb
+++ b/spec/support/termapp_helper.rb
@@ -1,7 +1,7 @@
 $LOAD_PATH.unshift(File.expand_path('../../../termapp', __FILE__))
 
 # Custom matchers for TermApp test.
-module TermAppHelpers
+module TermAppHelper
   extend RSpec::Matchers::DSL
 
   matcher :only_have_processors do |expected|

--- a/spec/termapp/application_spec.rb
+++ b/spec/termapp/application_spec.rb
@@ -3,8 +3,8 @@ require_relative '../../config/environment'
 require 'application'
 
 RSpec.describe TermApp::Application, type: :termapp do
-  include TermAppHelpers
-  include LoginHelpers
+  include TermAppHelper
+  include LoginHelper
 
   describe '.run' do
     subject(:app) { silence_warnings { TermApp::Application.new } }


### PR DESCRIPTION
- Move `LoginHelpers` to `spec/support/login_helper.rb`
- Rename `TermAppHelpers` to `TermAppHelper`
- Rename `LoginHelpers` to `LoginHelper`
