### PR TITLE
Handle space key properly

### DIFF
--- a/termapp/editors/less_editor.rb
+++ b/termapp/editors/less_editor.rb
@@ -48,7 +48,7 @@ module TermApp
           end
         when :q, :Q
           return nil, key
-        when :' '
+        when :space
           if @start_y + term_lines >= total_lines
             return nil, key
           end


### PR DESCRIPTION
KeyHelper::KEY_CODES convert key having its key code as 32 to `:space`, not `:' '`.
