### PR TITLE
Set timezone on initialization of Application

### DIFF
--- a/bin/term
+++ b/bin/term
@@ -2,7 +2,4 @@
 require_relative '../config/environment'
 require_relative '../termapp/application'
 
-# TODO : set timezone according to remote ip
-Time.zone = 'Asia/Seoul'
-
 TermApp::Application.new.run

--- a/termapp/application.rb
+++ b/termapp/application.rb
@@ -31,6 +31,8 @@ module TermApp
       @options, *_paths = Options.new.parse(args)
       @term = Terminal.new(debug: @options[:debug])
       @cached_processors = {}
+      # TODO: Set timezone according to remote IP.
+      Time.zone = 'Asia/Seoul'
     end
 
     # Run process of a passed Processors. Get the name of a Processor and


### PR DESCRIPTION
Let's keep `bin/term` empty as long as possible.
