### PR TITLE
Bump guard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ group :development do
   gem 'pry-remote'
   gem 'pry-stack_explorer'
   gem 'rubocop', '~> 0.27.0', require: false
-  gem 'guard', '~> 2.7.0', require: false
+  gem 'guard', '~> 2.10.0', require: false
   gem 'guard-rspec', require: false
   gem 'guard-rubocop', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
       railties (>= 3.0.0)
     ffi (1.9.6)
     formatador (0.2.5)
-    guard (2.7.3)
+    guard (2.10.2)
       formatador (>= 0.2.4)
       listen (~> 2.7)
       lumberjack (~> 1.0)
@@ -211,7 +211,7 @@ DEPENDENCIES
   bullet (~> 4.14.0)
   coffee-rails (~> 4.1.0)
   factory_girl_rails (~> 4.5.0)
-  guard (~> 2.7.0)
+  guard (~> 2.10.0)
   guard-rspec
   guard-rubocop
   jbuilder (~> 2.0)

--- a/Guardfile
+++ b/Guardfile
@@ -50,15 +50,3 @@ group :specs, halt_on_fail: true do
     watch(/.+\.rake$/)
   end
 end
-
-# Set default plugin scope of Guard to RuboCop. If you want to run RSpec plugin,
-# just type
-#
-#   rspec
-#
-# in Guard command line. Also you can type
-#
-#   scope specs
-#
-# in Guard command line to use both RSpec and RuboCop plugins by default.
-scope plugin: :rubocop


### PR DESCRIPTION
- Remove version requirements from `guard-rspec` and `guard-rubocop`. Let bundle manages their dependencies.
- Bump `guard` to 2.10.2. Removed default plugin scope. At first, there was no specs for this library, so we disabled it temporarily. But with guard 2.10.2, this is invalid statement and we added some specs, so now we remove plugin scope. See bafa69da3748931863622f1d5953b5d2ca403d50.
