### PR TITLE
Use fasterer for speed improvements

### DIFF
--- a/.fasterer.yml
+++ b/.fasterer.yml
@@ -1,0 +1,24 @@
+speedups:
+  parallel_assignment: false
+  rescue_vs_respond_to: true
+  module_eval: true
+  shuffle_first_vs_sample: true
+  for_loop_vs_each: true
+  each_with_index_vs_while: false
+  map_flatten_vs_flat_map: true
+  reverse_each_vs_reverse_each: true
+  select_first_vs_detect: true
+  select_last_vs_reverse_detect: true
+  sort_vs_sort_by: true
+  fetch_with_argument_vs_block: true
+  keys_each_vs_each_key: true
+  hash_merge_bang_vs_hash_brackets: true
+  block_vs_symbol_to_proc: true
+  proc_call_vs_yield: true
+  gsub_vs_tr: true
+  select_last_vs_reverse_detect: true
+  getter_vs_attr_reader: true
+  setter_vs_attr_writer: true
+
+exclude_paths:
+  - 'vendor/**/*.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :development do
   gem 'pry-remote'
   gem 'pry-stack_explorer'
   gem 'rubocop', '~> 0.33.0', require: false
+  gem 'fasterer', '~> 0.1', require: false
   gem 'guard', '~> 2.13.0', require: false
   gem 'guard-rspec', require: false
   gem 'guard-rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1.1)
+    colorize (0.7.7)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
@@ -73,6 +74,9 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
+    fasterer (0.1.11)
+      colorize (~> 0.7)
+      ruby_parser (~> 3.6)
     ffi (1.9.10)
     formatador (0.2.5)
     globalid (0.3.6)
@@ -202,6 +206,8 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
     ruby-progressbar (1.7.5)
+    ruby_parser (3.7.1)
+      sexp_processor (~> 4.1)
     sass (3.4.16)
     sass-rails (5.0.3)
       railties (>= 4.0.0, < 5.0)
@@ -212,6 +218,7 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    sexp_processor (4.6.0)
     shellany (0.0.1)
     slop (3.6.0)
     spring (1.3.6)
@@ -246,6 +253,7 @@ DEPENDENCIES
   bullet (~> 4.14.0)
   coffee-rails (~> 4.1.0)
   factory_girl_rails (~> 4.5.0)
+  fasterer (~> 0.1)
   guard (~> 2.13.0)
   guard-rspec
   guard-rubocop

--- a/termapp/processors/signup_menu.rb
+++ b/termapp/processors/signup_menu.rb
@@ -73,9 +73,9 @@ END
           else
             id.codepoints.each do |x|
               if x < 128
-                if (!(0x41..0x5a).include? x) &&
-                   (!(0x61..0x7a).include? x) &&
-                   (!(0x30..0x39).include? x)
+                if (!(0x41..0x5a).cover?(x)) &&
+                   (!(0x61..0x7a).cover?(x)) &&
+                   (!(0x30..0x39).cover?(x))
                   id = ''
                   print_message('아이디는 한글, 숫자, 영문만 사용 가능합니다')
                 end


### PR DESCRIPTION
Currently we import `.fasterer.yml` from the library repository, so note that `parallel_assignment` and `each_with_index_vs_while` are disabled by default.

Usage is simple. Just `fasterer` on the console. Task for rake is not yet implemented. If you don't want to include gem, I'll just update the commit to patch the code only.
